### PR TITLE
fix(code-interpreter): recover a thread whose container Azure has rec…

### DIFF
--- a/src/app/(authenticated)/api/chat/__tests__/route.test.ts
+++ b/src/app/(authenticated)/api/chat/__tests__/route.test.ts
@@ -283,19 +283,50 @@ describe("/api/chat route (AI SDK v6)", () => {
       expect(mockUpdateContainer).toHaveBeenCalledWith("t1", "cntr_precreated", "");
     });
 
-    it("reuses the thread's existing container without creating another", async () => {
+    it("revalidates the stored container each turn and writes nothing when it is unchanged", async () => {
+      // The guard here used to skip the check entirely once a thread had a
+      // container, so a reclaimed one was never replaced and every later turn
+      // failed on "Container is expired.". The check now runs every turn; an
+      // unchanged id still costs no Cosmos write and still gives the seam the
+      // same string, so the tool definition stays byte-stable.
       mockLoadThreadContext.mockResolvedValue({
         ...structuredClone(ciCtx),
         thread: { ...ciCtx.thread, codeInterpreterContainerId: "cntr_existing" },
       });
+      mockEnsureContainer.mockResolvedValue("cntr_existing");
 
       await POST(makeRequest({ message: "again", id: "t1", codeInterpreterEnabled: true }));
 
-      expect(mockEnsureContainer).not.toHaveBeenCalled();
+      expect(mockEnsureContainer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: "t1",
+          existingContainerId: "cntr_existing",
+        }),
+      );
+      expect(mockUpdateContainer).not.toHaveBeenCalled();
       expect(mockResolveProvider).toHaveBeenCalledWith(
         expect.objectContaining({
           thread: expect.objectContaining({
             codeInterpreterContainerId: "cntr_existing",
+          }),
+        }),
+      );
+    });
+
+    it("persists and declares a replacement when the stored container has expired", async () => {
+      mockLoadThreadContext.mockResolvedValue({
+        ...structuredClone(ciCtx),
+        thread: { ...ciCtx.thread, codeInterpreterContainerId: "cntr_dead" },
+      });
+      mockEnsureContainer.mockResolvedValue("cntr_fresh");
+
+      await POST(makeRequest({ message: "again", id: "t1", codeInterpreterEnabled: true }));
+
+      expect(mockUpdateContainer).toHaveBeenCalledWith("t1", "cntr_fresh", "");
+      expect(mockResolveProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thread: expect.objectContaining({
+            codeInterpreterContainerId: "cntr_fresh",
           }),
         }),
       );

--- a/src/app/(authenticated)/api/chat/route.ts
+++ b/src/app/(authenticated)/api/chat/route.ts
@@ -369,13 +369,23 @@ export async function POST(req: Request) {
   // Creating the container BEFORE the first model call puts the id in the
   // definition from turn 1 onwards. If creation fails we keep the old
   // bootstrap-then-harvest path, which still works.
-  if (effectiveToolsSafe.codeInterpreter && !ctx.thread.codeInterpreterContainerId) {
+  // Runs on EVERY code-interpreter turn, not only the first. The guard here
+  // used to be `&& !ctx.thread.codeInterpreterContainerId`, which meant a
+  // thread that once had a container never checked it again — so once Azure
+  // reclaimed it, every later turn declared a dead id and failed on
+  // "Container is expired." with no way out. ensureCodeInterpreterContainer
+  // now validates a stored id and replaces it only when it has really gone,
+  // so the steady state is still one container per thread and one stable tool
+  // definition.
+  if (effectiveToolsSafe.codeInterpreter) {
     const containerId = await ensureCodeInterpreterContainer({
       threadId: ctx.thread.id,
       existingContainerId: ctx.thread.codeInterpreterContainerId,
       fileIds: requestedCiFileIds,
     });
-    if (containerId) {
+    // Nothing to do when the id is unchanged: it is already on the thread and
+    // already persisted. Only a new or replaced container needs a write.
+    if (containerId && containerId !== ctx.thread.codeInterpreterContainerId) {
       // Persist BEFORE using it. The id has to survive to the next turn even
       // if the model never calls the tool this turn — otherwise turn 2 mints
       // another container and changes the definition again, which is the

--- a/src/features/chat-page/chat-services/code-interpreter-container.test.ts
+++ b/src/features/chat-page/chat-services/code-interpreter-container.test.ts
@@ -9,10 +9,16 @@ vi.mock("@/features/common/services/logger", () => ({
 }));
 
 const mockCreate = vi.fn();
+const mockRetrieve = vi.fn();
 let clientOverride: unknown = undefined;
 vi.mock("@/features/common/services/openai", () => ({
   OpenAIV1Instance: () =>
-    clientOverride ?? { containers: { create: (...a: unknown[]) => mockCreate(...(a as [])) } },
+    clientOverride ?? {
+      containers: {
+        create: (...a: unknown[]) => mockCreate(...(a as [])),
+        retrieve: (...a: unknown[]) => mockRetrieve(...(a as [])),
+      },
+    },
 }));
 
 import { ensureCodeInterpreterContainer } from "./code-interpreter-container";
@@ -20,16 +26,89 @@ import { ensureCodeInterpreterContainer } from "./code-interpreter-container";
 describe("ensureCodeInterpreterContainer", () => {
   beforeEach(() => {
     mockCreate.mockReset();
+    mockRetrieve.mockReset();
+    mockRetrieve.mockResolvedValue({ id: "cntr_existing", status: "running" });
     clientOverride = undefined;
   });
 
-  it("returns the existing container without calling the API", async () => {
+  it("reuses a stored container that is still alive, and mints nothing", async () => {
     const id = await ensureCodeInterpreterContainer({
       threadId: "t1",
       existingContainerId: "cntr_existing",
       fileIds: ["file-1"],
     });
     expect(id).toBe("cntr_existing");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("replaces a stored container that Azure has reclaimed", async () => {
+    // The live defect: the id outlives the container, so a thread idle past
+    // the window came back holding a dead id and every later turn failed on
+    // "Container is expired." — for good, because nothing replaced it.
+    mockRetrieve.mockRejectedValue(
+      Object.assign(new Error("Container is expired."), { status: 404 }),
+    );
+    mockCreate.mockResolvedValue({ id: "cntr_fresh" });
+
+    const id = await ensureCodeInterpreterContainer({
+      threadId: "t1",
+      existingContainerId: "cntr_dead",
+      fileIds: [],
+    });
+
+    expect(id).toBe("cntr_fresh");
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces a container that answers with status expired", async () => {
+    mockRetrieve.mockResolvedValue({ id: "cntr_dead", status: "expired" });
+    mockCreate.mockResolvedValue({ id: "cntr_fresh" });
+
+    const id = await ensureCodeInterpreterContainer({
+      threadId: "t1",
+      existingContainerId: "cntr_dead",
+      fileIds: [],
+    });
+
+    expect(id).toBe("cntr_fresh");
+  });
+
+  it("keeps the stored id when the probe fails for any reason but absence", async () => {
+    // A 500 or a network blip is not evidence the container is gone. Minting
+    // on a transient error would churn the tool definition — the very prefix
+    // instability this module exists to prevent — and bin a live working
+    // directory.
+    for (const err of [
+      Object.assign(new Error("boom"), { status: 500 }),
+      new Error("socket hang up"),
+    ]) {
+      mockCreate.mockReset();
+      mockRetrieve.mockReset();
+      mockRetrieve.mockRejectedValue(err);
+
+      const id = await ensureCodeInterpreterContainer({
+        threadId: "t1",
+        existingContainerId: "cntr_maybe",
+        fileIds: [],
+      });
+
+      expect(id).toBe("cntr_maybe");
+      expect(mockCreate).not.toHaveBeenCalled();
+    }
+  });
+
+  it("keeps the stored id on a surface with no retrieve method", async () => {
+    clientOverride = {
+      containers: { create: (...a: unknown[]) => mockCreate(...(a as [])) },
+    };
+
+    const id = await ensureCodeInterpreterContainer({
+      threadId: "t1",
+      existingContainerId: "cntr_unknowable",
+      fileIds: [],
+    });
+
+    expect(id).toBe("cntr_unknowable");
     expect(mockCreate).not.toHaveBeenCalled();
   });
 

--- a/src/features/chat-page/chat-services/code-interpreter-container.ts
+++ b/src/features/chat-page/chat-services/code-interpreter-container.ts
@@ -47,19 +47,81 @@ export interface EnsureContainerArgs {
 }
 
 /**
- * Returns the container id to declare on the code_interpreter tool, creating
- * one if the thread has none yet. Returns undefined only when creation was
- * not possible, in which case the caller must keep its previous behaviour.
+ * Is this container still there?
+ *
+ * `true` alive, `false` definitely gone, `undefined` cannot tell — the three
+ * cases are deliberately distinct, because "cannot tell" must reuse the id
+ * rather than mint a container on every turn. A retrieve that fails for any
+ * reason other than absence (a 500, a network blip, no retrieve method on
+ * this surface) is "cannot tell": the container is probably fine and the tool
+ * definition should not churn over a transient error.
+ */
+async function containerIsAlive(
+  client: unknown,
+  containerId: string,
+): Promise<boolean | undefined> {
+  const containers = (client as { containers?: { retrieve?: unknown } })
+    .containers;
+  if (typeof containers?.retrieve !== "function") return undefined;
+  try {
+    const got = await (
+      containers as {
+        retrieve: (id: string) => Promise<{ status?: string } | undefined>;
+      }
+    ).retrieve(containerId);
+    if (!got) return undefined;
+    // Azure reports a reclaimed container as "expired" when it still answers
+    // at all; treat anything else as usable.
+    return got.status !== "expired";
+  } catch (err) {
+    const status = (err as { status?: number; statusCode?: number })?.status
+      ?? (err as { statusCode?: number })?.statusCode;
+    const message =
+      err instanceof Error ? err.message.toLowerCase() : String(err).toLowerCase();
+    // Absence is the one answer we act on.
+    if (status === 404 || message.includes("expired") || message.includes("not found")) {
+      return false;
+    }
+    return undefined;
+  }
+}
+
+/**
+ * Returns the container id to declare on the code_interpreter tool. Creates
+ * one if the thread has none, and replaces the stored one if it has expired.
+ * Returns undefined only when creation was not possible, in which case the
+ * caller must keep its previous behaviour.
  */
 export async function ensureCodeInterpreterContainer({
   threadId,
   existingContainerId,
   fileIds,
 }: EnsureContainerArgs): Promise<string | undefined> {
-  if (existingContainerId) return existingContainerId;
-
   try {
     const client = OpenAIV1Instance();
+
+    // A stored id is not proof the container still exists. Azure reclaims a
+    // container CONTAINER_IDLE_MINUTES after its last activity, and the id
+    // outlives it in Cosmos, so a thread that was idle over lunch came back
+    // holding a dead id. Declaring it made every later turn fail on
+    // "Container is expired." — permanently, because nothing ever replaced
+    // it. Probe before reuse and mint a replacement when it has gone.
+    if (existingContainerId) {
+      const alive = await containerIsAlive(client, existingContainerId);
+      if (alive !== false) {
+        // Alive, or unknowable on this surface. Reuse: prefix stability is
+        // the whole point, and re-minting on a false alarm would throw away
+        // the working directory for nothing.
+        return existingContainerId;
+      }
+      logInfo(
+        "code-interpreter: stored container is gone, minting a replacement",
+        { threadId, expiredContainerId: existingContainerId },
+      );
+      // Fall through and create a new one. Nothing is lost that could have
+      // been saved: an expired container's files are already gone.
+    }
+
     // Older/self-hosted surfaces may not expose /containers at all. Probe
     // rather than throwing a TypeError into the request path.
     const containers = (client as { containers?: { create?: unknown } })


### PR DESCRIPTION
…laimed

A thread that used code_interpreter and then sat idle past the 20-minute window came back holding a container id that no longer pointed at anything. Every later turn declared the dead id, and the request failed:

  [ERROR] /api/chat streamText error
    "message": "Container is expired.", "name": "AI_APICallError"

Permanently, for that thread. The id lives in Cosmos and the container does not, and nothing ever compared the two: the route only asked for a container when the thread had none (`&& !ctx.thread.codeInterpreterContainerId`), so the one case that needed checking was the one case that was skipped. A new chat worked, which is what made this look like a broken conversation rather than a broken assumption. Seen on dev on a thread with 141 messages.

The check now runs on every code-interpreter turn, and reuses the stored container whenever it still exists:

  probe says alive        reuse the stored id, no write, no new container
  probe cannot tell       reuse the stored id
  probe says it is gone   mint a replacement, persist it, declare it

"Cannot tell" reuses on purpose. A 500, a socket hang-up or a surface with no `containers.retrieve` is not evidence of absence, and minting on a transient error would churn the tool definition — the prefix instability this module was written to remove — and discard a live working directory. Only a 404, or a retrieve that answers `status: "expired"`, counts as proof. When it is proof, nothing is lost that could have been kept: an expired container's files are already gone.

The steady state is unchanged: one container per thread, one byte-stable tool definition, and a Cosmos write only when the id actually changes.

The route test that asserted the container was NOT re-checked encoded the bug in an assertion; it now pins the revalidation and the no-write path, with a second test for the replacement. Container-module tests cover alive, reclaimed, status-expired, transient-failure and no-retrieve-method.